### PR TITLE
feat: add noindex/nofollow meta tag management based on environment v…

### DIFF
--- a/figma/.env.example
+++ b/figma/.env.example
@@ -8,3 +8,6 @@ VITE_API_BASE_URL=https://lpoybvmalhxlomsrssgm.supabase.co/functions/v1/make-ser
 
 # Laravel API base URL (without trailing slash)
 VITE_LARAVEL_API_BASE_URL=http://127.0.0.1:8000/api
+
+# Force noindex/nofollow robots meta on every page when set to true
+VITE_NOINDEXE=false

--- a/figma/src/components/SEOHead.tsx
+++ b/figma/src/components/SEOHead.tsx
@@ -15,6 +15,7 @@ const SITE_NAME = 'Memorialo';
 const DEFAULT_DESCRIPTION =
   'Memorialo es el marketplace para conectar proveedores de eventos con clientes en Venezuela. Encuentra los mejores servicios para bodas, fiestas, eventos corporativos y celebraciones.';
 const DEFAULT_OG_IMAGE = 'https://images.unsplash.com/photo-1519741497674-611481863552?w=1200&h=630&fit=crop';
+const forceNoindexByEnv = String((import.meta as any).env?.VITE_NOINDEXE ?? (import.meta as any).env?.VITE_NOINDEX ?? 'false').toLowerCase() === 'true';
 
 /**
  * SEOHead: Manages dynamic <head> meta tags for SEO.
@@ -31,6 +32,7 @@ export function SEOHead({
   structuredData,
   keywords,
 }: SEOHeadProps) {
+  const effectiveNoindex = noindex || forceNoindexByEnv;
   const fullTitle = title ? `${title} | ${SITE_NAME}` : `${SITE_NAME} - Marketplace de Servicios para Eventos`;
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
   const canonicalUrl = canonical ? `${origin}${canonical}` : `${origin}${window.location.pathname}`;
@@ -55,7 +57,7 @@ export function SEOHead({
     if (keywords) {
       setMeta('name', 'keywords', keywords);
     }
-    setMeta('name', 'robots', noindex ? 'noindex, nofollow' : 'index, follow');
+    setMeta('name', 'robots', effectiveNoindex ? 'noindex, nofollow' : 'index, follow');
 
     // --- Canonical ---
     let canonicalEl = document.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
@@ -138,7 +140,7 @@ export function SEOHead({
     return () => {
       document.querySelectorAll('script[data-seo-jsonld]').forEach((el) => el.remove());
     };
-  }, [fullTitle, description, canonicalUrl, ogImage, ogType, noindex, keywords, structuredData]);
+  }, [fullTitle, description, canonicalUrl, ogImage, ogType, effectiveNoindex, keywords, structuredData]);
 
   return null; // This component only manages <head>
 }

--- a/figma/src/main.tsx
+++ b/figma/src/main.tsx
@@ -3,5 +3,17 @@
   import App from "./App.tsx";
   import "./index.css";
 
+  const forceNoindexByEnv = String((import.meta as any).env?.VITE_NOINDEXE ?? (import.meta as any).env?.VITE_NOINDEX ?? "false").toLowerCase() === "true";
+
+  if (forceNoindexByEnv) {
+    let robotsMeta = document.querySelector('meta[name="robots"]') as HTMLMetaElement | null;
+    if (!robotsMeta) {
+      robotsMeta = document.createElement('meta');
+      robotsMeta.setAttribute('name', 'robots');
+      document.head.appendChild(robotsMeta);
+    }
+    robotsMeta.setAttribute('content', 'noindex, nofollow');
+  }
+
   createRoot(document.getElementById("root")!).render(<App />);
   


### PR DESCRIPTION
This pull request introduces a new environment variable to control whether all pages should be marked as "noindex, nofollow" for search engines, and updates the SEO handling logic to respect this setting both in the React component and at the entry point of the application. This allows for easy toggling of search engine indexing behavior across environments (e.g., staging vs. production).

Environment variable support:

* Added `VITE_NOINDEXE` to `.env.example` to allow forcing the "noindex, nofollow" robots meta tag on every page when set to `true`.

SEO logic updates:

* Updated `SEOHead.tsx` to check for the new environment variable and override the `noindex` prop if set, ensuring meta tags reflect the correct robots directive. [[1]](diffhunk://#diff-8e545e031a1b22570b338930c7e491431cb1baf711ff1cba814e32cbf4e5b5b3R18) [[2]](diffhunk://#diff-8e545e031a1b22570b338930c7e491431cb1baf711ff1cba814e32cbf4e5b5b3R35) [[3]](diffhunk://#diff-8e545e031a1b22570b338930c7e491431cb1baf711ff1cba814e32cbf4e5b5b3L58-R60) [[4]](diffhunk://#diff-8e545e031a1b22570b338930c7e491431cb1baf711ff1cba814e32cbf4e5b5b3L141-R143)
* Modified `main.tsx` to immediately set the robots meta tag to "noindex, nofollow" on page load if the environment variable is enabled, providing a fallback outside of React rendering.…ariable